### PR TITLE
docs: add build and test instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,6 +28,21 @@ This project is a Chrome and Firefox extension. The codebase includes manifest f
 3. **Reload after changes:**
    - After editing files, reload the extension in `about:debugging` to see updates.
 
+## Testing, Linting, and Building
+
+- **Run tests:**
+  ```sh
+  npm test
+  ```
+- **Lint the code:**
+  ```sh
+  npm run lint
+  ```
+- **Build the extension:**
+  ```sh
+  npm run build
+  ```
+
 ## Packaging
 - To distribute, zip the extension files (excluding unnecessary files like `.git/` or local configs) and submit to [Firefox Add-ons](https://addons.mozilla.org/).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,21 @@ feat: add user login functionality
 *   Keep your code clean, readable, and well-documented.
 *   Update documentation and translations as needed to reflect your changes.
 
+## Testing, Linting, and Building
+
+- **Run tests:**
+  ```sh
+  npm test
+  ```
+- **Lint the code:**
+  ```sh
+  npm run lint
+  ```
+- **Build the extension:**
+  ```sh
+  npm run build
+  ```
+
 ## Packaging
 
 To package the extension for distribution, create a zip archive of the project files, excluding any development-specific files (e.g., `.git`, local configurations). Submit the zip file to the [Firefox Add-ons](https://addons.mozilla.org/) platform.


### PR DESCRIPTION
Extends the GitHub CoPilot instructions and the agents.md file with information on how to run the jest tests and how to lint and build the App.