### PR TITLE
Enable webhook drag-and-drop sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This browser extension allows you to manage and trigger webhooks directly from y
 ## Features
 
 - **Manage Webhooks**: Add, edit, and remove webhook URLs from the extension options page.
+- **Reorder Webhooks**: Arrange your hooks via drag-and-drop on the options page.
 - **Trigger Webhooks**: Quickly trigger any configured webhook from the popup menu.
 - **Customizable**: Supports multiple webhooks with custom names and endpoints.
 - **Persistent Storage**: All webhooks are stored locally in your browser and persist across sessions.

--- a/options/options.css
+++ b/options/options.css
@@ -157,6 +157,7 @@ button:hover {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 8px;
     padding: 16px;
     border-bottom: 1px solid #e5e7eb;
     transition: background-color 0.2s;
@@ -170,6 +171,17 @@ button:hover {
 
 #webhook-list li:last-child {
     border-bottom: none;
+}
+
+.drag-handle {
+    cursor: grab;
+    user-select: none;
+    font-size: 1.2em;
+    color: #6b7280;
+}
+
+#webhook-list li.dragging {
+    opacity: 0.5;
 }
 
 .webhook-info {

--- a/tests/options.test.js
+++ b/tests/options.test.js
@@ -7,6 +7,7 @@ describe('options page', () => {
   let dom;
   let loadWebhooks;
   let saveWebhooks;
+  let persistWebhookOrder;
 
   beforeEach(() => {
     dom = new JSDOM(`<!DOCTYPE html><html><body>
@@ -64,7 +65,7 @@ describe('options page', () => {
     });
 
     // Load the options.js module
-    ({ loadWebhooks, saveWebhooks } = require('../options/options.js'));
+    ({ loadWebhooks, saveWebhooks, persistWebhookOrder } = require('../options/options.js'));
 
     // Manually trigger the DOMContentLoaded handler if it was captured
     if (domContentLoadedHandler) {
@@ -169,6 +170,23 @@ describe('options page', () => {
         identifier: 'test-identifier',
         customPayload
       }]
+    });
+  });
+
+  test('persistWebhookOrder stores list order', async () => {
+    const hooks = [
+      { id: '1', label: 'A', url: 'a' },
+      { id: '2', label: 'B', url: 'b' }
+    ];
+    global.browser.storage.sync.get.mockResolvedValue({ webhooks: hooks });
+    await loadWebhooks();
+    const list = document.getElementById('webhook-list');
+    list.appendChild(list.firstElementChild); // reorder DOM
+
+    await persistWebhookOrder();
+
+    expect(global.browser.storage.sync.set).toHaveBeenLastCalledWith({
+      webhooks: [hooks[1], hooks[0]]
     });
   });
 });


### PR DESCRIPTION
## Summary
- add drag handle for sorting
- save webhook order via drag-and-drop
- expose order persistence for tests
- style draggable list
- document new feature
- test webhook order persistence

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6873de405ecc832fb7d6ed10a0339bce