### PR TITLE
Add toggle for webhook form

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -118,5 +118,9 @@
   "optionsCancelEditButton": {
     "message": "Abbrechen",
     "description": "Text für den Abbrechen-Button im Bearbeiten-Modus."
+  },
+  "optionsAddNewWebhookButton": {
+    "message": "Neuen Webhook hinzufügen",
+    "description": "Schaltfläche um das Formular zum Hinzufügen zu öffnen."
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -118,5 +118,9 @@
   "optionsCancelEditButton": {
     "message": "Cancel",
     "description": "Text for the cancel button in edit mode."
+  },
+  "optionsAddNewWebhookButton": {
+    "message": "Add new webhook",
+    "description": "Button text to open the add webhook form."
   }
 }

--- a/options/options.css
+++ b/options/options.css
@@ -221,6 +221,10 @@ button:hover {
     background-color: #dc2626;
 }
 
+#add-new-webhook-btn {
+    margin-bottom: 20px;
+}
+
 .hidden {
     display: none !important;
 }

--- a/options/options.html
+++ b/options/options.html
@@ -10,8 +10,11 @@
         <div class="container">
             <h1>__MSG_optionsPageHeader__</h1>
             <p>__MSG_optionsPageDescription__</p>
+            <button type="button" id="add-new-webhook-btn">
+                __MSG_optionsAddNewWebhookButton__
+            </button>
 
-            <form id="add-webhook-form">
+            <form id="add-webhook-form" class="hidden">
                 <h2>__MSG_optionsAddWebhookHeader__</h2>
                 <div class="form-group">
                     <label for="webhook-label">__MSG_optionsLabelInputLabel__</label>

--- a/options/options.js
+++ b/options/options.js
@@ -76,11 +76,18 @@ const headerKeyInput = document.getElementById("header-key");
 const headerValueInput = document.getElementById("header-value");
 const addHeaderBtn = document.getElementById("add-header-btn");
 const cancelEditBtn = document.getElementById("cancel-edit-btn");
+const showAddWebhookBtn = document.getElementById("add-new-webhook-btn");
 const customPayloadInput = document.getElementById("webhook-custom-payload");
 const variablesAutocomplete = document.getElementById("variables-autocomplete");
 const toggleCustomPayloadBtn = document.getElementById("toggle-custom-payload");
 const customPayloadContent = document.getElementById("custom-payload-content");
 let headers = [];
+
+showAddWebhookBtn.addEventListener('click', () => {
+  form.classList.remove('hidden');
+  showAddWebhookBtn.classList.add('hidden');
+  labelInput.focus();
+});
 
 // Define available variables for autocompletion
 const availableVariables = [
@@ -289,6 +296,8 @@ form.addEventListener("submit", async (e) => {
   form.querySelector('button[type="submit"]').textContent = browser.i18n.getMessage("optionsSaveButton") || "Save Webhook";
   // Collapse custom payload section
   updateCustomPayloadVisibility();
+  form.classList.add('hidden');
+  showAddWebhookBtn.classList.remove('hidden');
   loadWebhooks();
 });
 
@@ -374,6 +383,8 @@ webhookList.addEventListener("click", async (e) => {
       headers = Array.isArray(webhook.headers) ? [...webhook.headers] : [];
       renderHeaders();
       cancelEditBtn.classList.remove("hidden");
+      form.classList.remove('hidden');
+      showAddWebhookBtn.classList.add('hidden');
       // Always set to save button when entering edit mode
       form.querySelector('button[type="submit"]').textContent = browser.i18n.getMessage("optionsSaveButton") || "Save Webhook";
 
@@ -401,6 +412,8 @@ cancelEditBtn.addEventListener("click", () => {
   form.querySelector('button[type="submit"]').textContent = browser.i18n.getMessage("optionsSaveButton") || "Save Webhook";
   // Collapse custom payload section
   updateCustomPayloadVisibility();
+  form.classList.add('hidden');
+  showAddWebhookBtn.classList.remove('hidden');
 });
 
 // Toggle custom payload section
@@ -460,6 +473,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Set localized label for cancel edit button
   cancelEditBtn.textContent = browser.i18n.getMessage("optionsCancelEditButton") || "Cancel";
+  showAddWebhookBtn.textContent = browser.i18n.getMessage("optionsAddNewWebhookButton") || "Add new webhook";
 
   // Initialize custom payload section (collapsed by default)
   updateCustomPayloadVisibility();

--- a/tests/options.test.js
+++ b/tests/options.test.js
@@ -11,7 +11,8 @@ describe('options page', () => {
 
   beforeEach(() => {
     dom = new JSDOM(`<!DOCTYPE html><html><body>
-      <form id="add-webhook-form">
+      <button type="button" id="add-new-webhook-btn"></button>
+      <form id="add-webhook-form" class="hidden">
         <input id="webhook-label" />
         <input id="webhook-url" />
         <select id="webhook-method"></select>


### PR DESCRIPTION
## Summary
- show webhook form only after clicking **Add new webhook**
- update German and English translations
- adjust tests for new button

## Testing
- `npm test`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6873f1c96dac832f8f161e8bf2b0780d