### PR TITLE
feat: add webhook grouping

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -122,5 +122,13 @@
   "optionsAddNewWebhookButton": {
     "message": "Neuen Webhook hinzufügen",
     "description": "Schaltfläche um das Formular zum Hinzufügen zu öffnen."
+  },
+  "optionsGroupInputLabel": {
+    "message": "Gruppe (optional)",
+    "description": "Label für das Eingabefeld der Webhook-Gruppe."
+  },
+  "optionsGroupInputPlaceholder": {
+    "message": "Gruppenname",
+    "description": "Platzhalter für das Eingabefeld der Webhook-Gruppe."
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -122,5 +122,13 @@
   "optionsAddNewWebhookButton": {
     "message": "Add new webhook",
     "description": "Button text to open the add webhook form."
+  },
+  "optionsGroupInputLabel": {
+    "message": "Group (optional)",
+    "description": "Label for the webhook group input field."
+  },
+  "optionsGroupInputPlaceholder": {
+    "message": "Group name",
+    "description": "Placeholder for the webhook group input field."
   }
 }

--- a/options/options.css
+++ b/options/options.css
@@ -148,12 +148,11 @@ button:hover {
     margin-top: 0;
 }
 
-#webhook-list {
+.webhook-list {
     list-style-type: none;
     padding: 0;
 }
-
-#webhook-list li {
+.webhook-list li {
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -163,13 +162,10 @@ button:hover {
     transition: background-color 0.2s;
     border-radius: 8px;
     margin-bottom: 8px;
-}
-
-#webhook-list li:hover {
+.webhook-list li:hover {
     background-color: #f9fafb;
 }
-
-#webhook-list li:last-child {
+.webhook-list li:last-child {
     border-bottom: none;
 }
 
@@ -180,7 +176,25 @@ button:hover {
     color: #6b7280;
 }
 
-#webhook-list li.dragging {
+.webhook-group {
+    margin-bottom: 24px;
+}
+
+.group-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+.group-drag-handle {
+    cursor: grab;
+    user-select: none;
+    font-size: 1.2em;
+    color: #6b7280;
+}
+
+.webhook-list li.dragging {
     opacity: 0.5;
 }
 

--- a/options/options.html
+++ b/options/options.html
@@ -55,6 +55,14 @@
                     <input type="text" id="webhook-identifier" placeholder="Optional identifier" />
                 </div>
                 <div class="form-group">
+                    <label for="webhook-group">__MSG_optionsGroupInputLabel__</label>
+                    <input
+                        type="text"
+                        id="webhook-group"
+                        placeholder="__MSG_optionsGroupInputPlaceholder__"
+                    />
+                </div>
+                <div class="form-group">
                     <div class="collapsible-header" id="url-filter-header">
                         <label for="webhook-url-filter">URL Filter (optional)</label>
                         <button type="button" id="toggle-url-filter" class="toggle-btn" aria-expanded="false">
@@ -106,9 +114,9 @@
 
             <h2>__MSG_optionsStoredWebhooksHeader__</h2>
             <div id="webhook-list-container">
-                <ul id="webhook-list">
+                <div id="webhook-groups-container">
                     <!-- Gespeicherte Webhooks werden hier dynamisch eingefügt -->
-                </ul>
+                </div>
                 <p id="no-webhooks-message" class="hidden">
                     __MSG_optionsNoWebhooksMessage__
                 </p>

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -29,6 +29,15 @@ body {
     gap: 10px;
 }
 
+.popup-group {
+    margin-bottom: 10px;
+}
+
+.popup-group h4 {
+    margin: 0 0 5px 0;
+    font-size: 1em;
+}
+
 .webhook-btn {
     width: 100%;
     padding: 12px;

--- a/tests/options.test.js
+++ b/tests/options.test.js
@@ -17,6 +17,7 @@ describe('options page', () => {
         <input id="webhook-url" />
         <select id="webhook-method"></select>
         <input id="webhook-identifier" />
+        <input id="webhook-group" />
         <div id="headers-list"></div>
         <input id="header-key" />
         <input id="header-value" />
@@ -41,7 +42,7 @@ describe('options page', () => {
         <button type="button" id="cancel-edit-btn" class="hidden"></button>
         <button type="submit"></button>
       </form>
-      <ul id="webhook-list"></ul>
+      <div id="webhook-groups-container"></div>
       <p id="no-webhooks-message" class="hidden"></p>
     </body></html>`);
     global.document = dom.window.document;
@@ -101,10 +102,10 @@ describe('options page', () => {
   });
 
   test('renders list items when webhooks exist', async () => {
-    const hooks = [{ id: '1', label: 'Test', url: 'http://example.com' }];
-    global.browser.storage.sync.get.mockResolvedValue({ webhooks: hooks });
+    const hooks = [{ id: '1', label: 'Test', url: 'http://example.com', group: 'A' }];
+    global.browser.storage.sync.get.mockResolvedValue({ webhooks: hooks, groupOrder: ['A'] });
     await loadWebhooks();
-    const items = document.querySelectorAll('#webhook-list li');
+    const items = document.querySelectorAll('#webhook-groups-container li');
     expect(items.length).toBe(1);
     const item = items[0];
     expect(item.dataset.id).toBe('1');
@@ -179,25 +180,28 @@ describe('options page', () => {
         ],
         identifier: 'test-identifier',
         customPayload,
-        urlFilter: 'example.com'
-      }]
+        urlFilter: 'example.com',
+        group: ''
+      }],
+      groupOrder: []
     });
   });
 
   test('persistWebhookOrder stores list order', async () => {
     const hooks = [
-      { id: '1', label: 'A', url: 'a' },
-      { id: '2', label: 'B', url: 'b' }
+      { id: '1', label: 'A', url: 'a', group: 'g' },
+      { id: '2', label: 'B', url: 'b', group: 'g' }
     ];
-    global.browser.storage.sync.get.mockResolvedValue({ webhooks: hooks });
+    global.browser.storage.sync.get.mockResolvedValue({ webhooks: hooks, groupOrder: ['g'] });
     await loadWebhooks();
-    const list = document.getElementById('webhook-list');
+    const list = document.querySelector('#webhook-groups-container ul');
     list.appendChild(list.firstElementChild); // reorder DOM
 
     await persistWebhookOrder();
 
     expect(global.browser.storage.sync.set).toHaveBeenLastCalledWith({
-      webhooks: [hooks[1], hooks[0]]
+      webhooks: [hooks[1], hooks[0]],
+      groupOrder: ['g']
     });
   });
 });


### PR DESCRIPTION
## Summary
- add optional group field to webhook form
- store and load webhooks grouped by group name
- allow drag and drop sorting of groups and webhooks
- display groups in popup and hide empty groups
- update translations and tests

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6874b818e990832f92efddfe9428dbae