### PR TITLE
Add export and import tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This browser extension allows you to manage and trigger webhooks directly from y
 - **Customizable**: Supports multiple webhooks with custom names and endpoints.
 - **Persistent Storage**: All webhooks are stored locally in your browser and persist across sessions.
 - **Localization**: Available in multiple languages (see `_locales/`).
+- **Export/Import Configuration**: Backup or restore your webhooks using JSON files.
 
 ## Getting Started
 

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -182,5 +182,17 @@
   "optionsAvailableVariablesText": {
     "message": "Verfügbare Variablen:",
     "description": "Einleitungstext für den Variablen-Hilfebereich."
+  },
+  "optionsExportButton": {
+    "message": "Webhooks exportieren",
+    "description": "Button-Text zum Export aller Webhooks."
+  },
+  "optionsImportButton": {
+    "message": "Webhooks importieren",
+    "description": "Button-Text zum Import von Webhooks aus einer Datei."
+  },
+  "optionsImportInfo": {
+    "message": "Beim Import werden vorhandene Webhooks ersetzt.",
+    "description": "Hinweistext neben dem Import-Button."
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -182,5 +182,17 @@
   "optionsAvailableVariablesText": {
     "message": "Available variables:",
     "description": "Intro text for the variables help section."
+  },
+  "optionsExportButton": {
+    "message": "Export Webhooks",
+    "description": "Button text to export all webhooks."
+  },
+  "optionsImportButton": {
+    "message": "Import Webhooks",
+    "description": "Button text to import webhooks from a file."
+  },
+  "optionsImportInfo": {
+    "message": "Importing replaces all existing webhooks.",
+    "description": "Information text shown next to the import button."
   }
 }

--- a/options/options.css
+++ b/options/options.css
@@ -298,3 +298,16 @@ button:hover {
     color: #2563eb;
     font-size: 0.9em;
 }
+
+#import-export-actions {
+    margin-top: 20px;
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+#import-export-actions .import-info {
+    margin: 0;
+    color: #4b5563;
+}

--- a/options/options.html
+++ b/options/options.html
@@ -113,6 +113,19 @@
                     __MSG_optionsNoWebhooksMessage__
                 </p>
             </div>
+
+            <div id="import-export-actions">
+                <button type="button" id="export-webhooks-btn">
+                    __MSG_optionsExportButton__
+                </button>
+                <button type="button" id="import-webhooks-btn">
+                    __MSG_optionsImportButton__
+                </button>
+                <input type="file" id="import-webhooks-input" accept="application/json" class="hidden" />
+                <p id="import-info" class="import-info">
+                    __MSG_optionsImportInfo__
+                </p>
+            </div>
         </div>
 
         <script src="../utils/browser-polyfill.js"></script>

--- a/tests/exportImport.test.js
+++ b/tests/exportImport.test.js
@@ -1,0 +1,134 @@
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+const { JSDOM } = require('jsdom');
+
+describe('export and import logic', () => {
+  let dom;
+  let exportWebhooks;
+  let handleImport;
+
+  beforeEach(() => {
+    dom = new JSDOM(`<!DOCTYPE html><html><body>
+      <button type="button" id="add-new-webhook-btn"></button>
+      <form id="add-webhook-form" class="hidden">
+        <input id="webhook-label" />
+        <input id="webhook-url" />
+        <select id="webhook-method"></select>
+        <input id="webhook-identifier" />
+        <div id="headers-list"></div>
+        <input id="header-key" />
+        <input id="header-value" />
+        <button type="button" id="add-header-btn"></button>
+        <div class="collapsible-header" id="url-filter-header">
+          <button type="button" id="toggle-url-filter" class="toggle-btn" aria-expanded="false">
+            <span class="toggle-icon">+</span>
+          </button>
+        </div>
+        <div id="url-filter-content" class="collapsible-content collapsed">
+          <input id="webhook-url-filter" />
+        </div>
+        <div class="collapsible-header" id="custom-payload-header">
+          <button type="button" id="toggle-custom-payload" class="toggle-btn" aria-expanded="false">
+            <span class="toggle-icon">+</span>
+          </button>
+        </div>
+        <div id="custom-payload-content" class="collapsible-content collapsed">
+          <textarea id="webhook-custom-payload"></textarea>
+          <div id="variables-autocomplete" class="autocomplete-container hidden"></div>
+        </div>
+        <button type="button" id="cancel-edit-btn" class="hidden"></button>
+        <button type="submit"></button>
+      </form>
+      <div id="import-export-actions">
+        <button type="button" id="export-webhooks-btn"></button>
+        <button type="button" id="import-webhooks-btn"></button>
+        <input type="file" id="import-webhooks-input" />
+      </div>
+      <ul id="webhook-list"></ul>
+      <p id="no-webhooks-message" class="hidden"></p>
+    </body></html>`);
+
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.Node = dom.window.Node;
+    global.replaceI18nPlaceholders = jest.fn();
+
+    global.browser = {
+      storage: {
+        sync: {
+          get: jest.fn().mockResolvedValue({ webhooks: [] }),
+          set: jest.fn(),
+        },
+      },
+      i18n: { getMessage: jest.fn((k) => k) },
+    };
+    global.window.getBrowserAPI = jest.fn().mockReturnValue(global.browser);
+
+    const originalAddEventListener = dom.window.document.addEventListener;
+    let domContentLoadedHandler;
+    dom.window.document.addEventListener = jest.fn((event, handler) => {
+      if (event === 'DOMContentLoaded') {
+        domContentLoadedHandler = handler;
+      } else {
+        originalAddEventListener.call(dom.window.document, event, handler);
+      }
+    });
+
+    const module = require('../options/options.js');
+    exportWebhooks = module.exportWebhooks;
+    handleImport = module.handleImport;
+
+    if (domContentLoadedHandler) {
+      domContentLoadedHandler();
+    }
+
+    global.URL.createObjectURL = jest.fn().mockReturnValue('blob:url');
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    dom.window.close();
+    delete global.document;
+    delete global.window.getBrowserAPI;
+    delete global.window;
+    delete global.Node;
+    delete global.browser;
+    delete global.replaceI18nPlaceholders;
+    delete global.URL.createObjectURL;
+  });
+
+  test('exportWebhooks creates downloadable file with stored hooks', async () => {
+    const hooks = [{ id: '1', label: 'A', url: 'https://example.com' }];
+    global.browser.storage.sync.get.mockResolvedValue({ webhooks: hooks });
+
+    const clickSpy = jest.fn();
+    const originalCreateElement = dom.window.document.createElement.bind(dom.window.document);
+    jest.spyOn(dom.window.document, 'createElement').mockImplementation((tag) => {
+      if (tag === 'a') {
+        return { href: '', download: '', click: clickSpy };
+      }
+      return originalCreateElement(tag);
+    });
+
+    await exportWebhooks();
+
+    expect(global.URL.createObjectURL).toHaveBeenCalled();
+    const blob = global.URL.createObjectURL.mock.calls[0][0];
+    const text = await blob.text();
+    expect(JSON.parse(text)).toEqual({ webhooks: hooks });
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  test('handleImport saves hooks from uploaded file', async () => {
+    const hooks = [{ id: '1', label: 'A', url: 'https://example.com' }];
+    const file = new File([JSON.stringify({ webhooks: hooks })], 'webhooks.json', { type: 'application/json' });
+
+    const event = { target: { files: [file], value: 'test' } };
+
+    await handleImport(event);
+
+    expect(global.browser.storage.sync.set).toHaveBeenCalledWith({ webhooks: hooks });
+    expect(event.target.value).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- export functions for testing
- test export and import logic of options page

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687548be8e7c832f90c43db4852d6fd5