### PR TITLE
Add webhook duplication support

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -115,6 +115,10 @@
     "message": "Bearbeiten",
     "description": "Text für den Bearbeiten-Button."
   },
+  "optionsDuplicateButton": {
+    "message": "Duplizieren",
+    "description": "Text für den Duplizieren-Button."
+  },
   "optionsCancelEditButton": {
     "message": "Abbrechen",
     "description": "Text für den Abbrechen-Button im Bearbeiten-Modus."

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -115,6 +115,10 @@
     "message": "Edit",
     "description": "Text for the edit button."
   },
+  "optionsDuplicateButton": {
+    "message": "Duplicate",
+    "description": "Text for the duplicate button."
+  },
   "optionsCancelEditButton": {
     "message": "Cancel",
     "description": "Text for the cancel button in edit mode."

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
   "permissions": [

--- a/options/options.css
+++ b/options/options.css
@@ -213,6 +213,15 @@ button:hover {
     background-color: #059669;
 }
 
+.duplicate-btn {
+    margin-right: 8px;
+    background-color: #3b82f6;
+}
+
+.duplicate-btn:hover {
+    background-color: #2563eb;
+}
+
 .delete-btn {
     background-color: #ef4444;
 }

--- a/options/options.js
+++ b/options/options.js
@@ -421,7 +421,7 @@ webhookList.addEventListener("click", async (e) => {
       headerValueInput.value = "";
       headers = [];
       renderHeaders();
-      cancelEditBtn.classList.remove("hidden");
+      cancelEditBtn.classList.add("hidden");
       form.querySelector('button[type="submit"]').textContent = browser.i18n.getMessage("optionsSaveButton") || "Save Webhook";
     }
   } else if (e.target.classList.contains("edit-btn")) {

--- a/options/options.js
+++ b/options/options.js
@@ -134,6 +134,7 @@ if (importWebhooksBtn && importWebhooksInput) {
 showAddWebhookBtn.addEventListener('click', () => {
   form.classList.remove('hidden');
   showAddWebhookBtn.classList.add('hidden');
+  cancelEditBtn.classList.remove('hidden');
   labelInput.focus();
 });
 

--- a/options/options.js
+++ b/options/options.js
@@ -421,7 +421,7 @@ webhookList.addEventListener("click", async (e) => {
       headerValueInput.value = "";
       headers = [];
       renderHeaders();
-      cancelEditBtn.classList.add("hidden");
+      cancelEditBtn.classList.remove("hidden");
       form.querySelector('button[type="submit"]').textContent = browser.i18n.getMessage("optionsSaveButton") || "Save Webhook";
     }
   } else if (e.target.classList.contains("edit-btn")) {
@@ -461,7 +461,7 @@ webhookList.addEventListener("click", async (e) => {
       customPayloadInput.value = webhook.customPayload || "";
       headers = Array.isArray(webhook.headers) ? [...webhook.headers] : [];
       renderHeaders();
-      cancelEditBtn.classList.add("hidden");
+      cancelEditBtn.classList.remove("hidden");
       form.classList.remove('hidden');
       showAddWebhookBtn.classList.add('hidden');
       form.querySelector('button[type="submit"]').textContent = browser.i18n.getMessage("optionsSaveButton") || "Save Webhook";

--- a/options/options.js
+++ b/options/options.js
@@ -45,9 +45,14 @@ const loadWebhooks = async () => {
       editButton.textContent = browser.i18n.getMessage("optionsEditButton") || "Edit";
       editButton.classList.add("edit-btn");
 
+      const duplicateButton = document.createElement("button");
+      duplicateButton.textContent = browser.i18n.getMessage("optionsDuplicateButton") || "Duplicate";
+      duplicateButton.classList.add("duplicate-btn");
+
       listItem.appendChild(dragHandle);
       listItem.appendChild(textContent);
       listItem.appendChild(editButton);
+      listItem.appendChild(duplicateButton);
       listItem.appendChild(deleteButton);
       list.appendChild(listItem);
     });
@@ -442,6 +447,26 @@ webhookList.addEventListener("click", async (e) => {
       updateCustomPayloadVisibility();
       updateUrlFilterVisibility();
 
+      labelInput.focus();
+    }
+  } else if (e.target.classList.contains("duplicate-btn")) {
+    const webhook = webhooks.find((wh) => wh.id === webhookId);
+    if (webhook) {
+      editWebhookId = null;
+      labelInput.value = webhook.label;
+      urlInput.value = webhook.url;
+      methodSelect.value = webhook.method || "POST";
+      identifierInput.value = webhook.identifier || "";
+      urlFilterInput.value = webhook.urlFilter || "";
+      customPayloadInput.value = webhook.customPayload || "";
+      headers = Array.isArray(webhook.headers) ? [...webhook.headers] : [];
+      renderHeaders();
+      cancelEditBtn.classList.add("hidden");
+      form.classList.remove('hidden');
+      showAddWebhookBtn.classList.add('hidden');
+      form.querySelector('button[type="submit"]').textContent = browser.i18n.getMessage("optionsSaveButton") || "Save Webhook";
+      updateCustomPayloadVisibility();
+      updateUrlFilterVisibility();
       labelInput.focus();
     }
   }

--- a/tests/options.test.js
+++ b/tests/options.test.js
@@ -226,4 +226,13 @@ describe('options page', () => {
     expect(document.getElementById('add-new-webhook-btn').classList.contains('hidden')).toBe(true);
     expect(document.getElementById('add-webhook-form').classList.contains('hidden')).toBe(false);
   });
+
+  test('add new webhook shows cancel button', async () => {
+    const addBtn = document.getElementById('add-new-webhook-btn');
+    addBtn.click();
+
+    expect(document.getElementById('cancel-edit-btn').classList.contains('hidden')).toBe(false);
+    expect(document.getElementById('add-webhook-form').classList.contains('hidden')).toBe(false);
+    expect(document.getElementById('add-new-webhook-btn').classList.contains('hidden')).toBe(true);
+  });
 });

--- a/tests/options.test.js
+++ b/tests/options.test.js
@@ -202,4 +202,28 @@ describe('options page', () => {
       webhooks: [hooks[1], hooks[0]]
     });
   });
+
+  test('duplicate button prefills the form without edit mode', async () => {
+    const hooks = [{
+      id: '1',
+      label: 'Hook',
+      url: 'https://example.com',
+      method: 'POST',
+      identifier: 'id1',
+      urlFilter: 'example.com',
+      customPayload: '',
+      headers: [{ key: 'X', value: '1' }]
+    }];
+    global.browser.storage.sync.get.mockResolvedValue({ webhooks: hooks });
+    await loadWebhooks();
+    const duplicateBtn = document.querySelector('.duplicate-btn');
+    duplicateBtn.click();
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(document.getElementById('webhook-label').value).toBe('Hook');
+    expect(document.getElementById('webhook-url').value).toBe('https://example.com');
+    expect(document.getElementById('cancel-edit-btn').classList.contains('hidden')).toBe(true);
+    expect(document.getElementById('add-new-webhook-btn').classList.contains('hidden')).toBe(true);
+    expect(document.getElementById('add-webhook-form').classList.contains('hidden')).toBe(false);
+  });
 });

--- a/tests/options.test.js
+++ b/tests/options.test.js
@@ -222,7 +222,7 @@ describe('options page', () => {
 
     expect(document.getElementById('webhook-label').value).toBe('Hook');
     expect(document.getElementById('webhook-url').value).toBe('https://example.com');
-    expect(document.getElementById('cancel-edit-btn').classList.contains('hidden')).toBe(true);
+    expect(document.getElementById('cancel-edit-btn').classList.contains('hidden')).toBe(false);
     expect(document.getElementById('add-new-webhook-btn').classList.contains('hidden')).toBe(true);
     expect(document.getElementById('add-webhook-form').classList.contains('hidden')).toBe(false);
   });


### PR DESCRIPTION
## Summary
- add Duplicate button translations
- enable duplication via new button in options page
- style the new duplicate button
- test duplicating an existing webhook

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68760364cf8c832fbd60fa3392c06a06