### PR TITLE
Add context menu webhook trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This browser extension allows you to manage and trigger webhooks directly from y
 1. Click the extension icon in your browser's toolbar to open the popup.
 2. Select the webhook you want to trigger from the list.
 3. Click the "Send" or equivalent button to trigger the webhook.
+4. Alternatively, right-click a page and choose the webhook from the context menu.
 
 ## Localization
 

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -202,5 +202,15 @@
   "optionsSendSelectedTextLabel": {
     "message": "Ausgewählten Text senden",
     "description": "Beschriftung für die Checkbox, um ausgewählten Text zu übermitteln."
+  },
+  "contextMenuSend": {
+    "message": "Senden an $label$",
+    "description": "Kontextmenüeintrag zum Auslösen eines Webhooks",
+    "placeholders": {
+      "label": {
+        "content": "$1",
+        "example": "Mein Hook"
+      }
+    }
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -202,5 +202,15 @@
   "optionsSendSelectedTextLabel": {
     "message": "Send selected text",
     "description": "Label for checkbox to include selected text in the payload."
+  },
+  "contextMenuSend": {
+    "message": "Send to $label$",
+    "description": "Context menu entry to trigger a webhook",
+    "placeholders": {
+      "label": {
+        "content": "$1",
+        "example": "My Hook"
+      }
+    }
   }
 }

--- a/background.js
+++ b/background.js
@@ -1,0 +1,53 @@
+// Background script to handle context menu webhook triggering
+if (typeof importScripts === 'function') {
+  importScripts('/utils/browser-polyfill.js', '/utils/sendWebhook.js');
+}
+
+const browserAPI = window.getBrowserAPI();
+let webhookMap = {};
+
+let sendWebhook;
+if (typeof module !== 'undefined' && module.exports) {
+  sendWebhook = require('./utils/sendWebhook').sendWebhook;
+} else {
+  sendWebhook = window.sendWebhook;
+}
+
+async function loadWebhooks() {
+  const { webhooks = [] } = await browserAPI.storage.sync.get('webhooks');
+  webhookMap = Object.fromEntries(webhooks.map(w => [w.id, w]));
+  return webhooks;
+}
+
+async function createContextMenus() {
+  if (browserAPI.contextMenus.removeAll) {
+    await browserAPI.contextMenus.removeAll();
+  }
+  const hooks = await loadWebhooks();
+  hooks.forEach(hook => {
+    const title = browserAPI.i18n.getMessage('contextMenuSend', hook.label) || hook.label;
+    browserAPI.contextMenus.create({
+      id: hook.id,
+      title,
+      contexts: ['all'],
+    });
+  });
+}
+
+
+browserAPI.runtime.onInstalled?.addListener(createContextMenus);
+browserAPI.runtime.onStartup?.addListener(createContextMenus);
+browserAPI.storage.onChanged?.addListener(createContextMenus);
+
+browserAPI.contextMenus.onClicked.addListener(async (info, tab) => {
+  const hook = webhookMap[info.menuItemId];
+  if (hook) {
+    await sendWebhook(hook, tab, info);
+  }
+});
+
+createContextMenus();
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { createContextMenus, sendWebhook };
+}

--- a/manifest.json
+++ b/manifest.json
@@ -6,11 +6,16 @@
   "default_locale": "en",
   "permissions": [
     "storage",
-    "activeTab"
+    "activeTab",
+    "contextMenus"
   ],
   "host_permissions": [
     "<all_urls>"
   ],
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": false
+  },
   "action": {
     "default_popup": "popup/popup.html",
     "default_icon": {

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -20,6 +20,7 @@
         </div>
         <script src="../utils/browser-polyfill.js"></script>
         <script src="../utils/utils.js"></script>
+        <script src="../utils/sendWebhook.js"></script>
         <script src="popup.js"></script>
     </body>
 </html>

--- a/tests/contextMenu.test.js
+++ b/tests/contextMenu.test.js
@@ -1,0 +1,49 @@
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+
+
+describe('background context menu', () => {
+  let browser;
+  let fetchMock;
+  let createContextMenus;
+  let sendWebhook;
+
+  beforeEach(() => {
+    fetchMock = jest.fn().mockResolvedValue({ ok: true });
+    global.fetch = fetchMock;
+    browser = {
+      storage: {
+        sync: { get: jest.fn().mockResolvedValue({ webhooks: [{ id: '1', label: 'Test', url: 'https://hook.test' }] }) }
+      },
+      contextMenus: {
+        create: jest.fn(),
+        removeAll: jest.fn(),
+        onClicked: { addListener: jest.fn() },
+      },
+      i18n: { getMessage: jest.fn((_k, s) => s) },
+      runtime: { getBrowserInfo: jest.fn().mockResolvedValue({}), getPlatformInfo: jest.fn().mockResolvedValue({}) },
+    };
+    global.browser = browser;
+    global.window = { getBrowserAPI: () => browser };
+    ({ createContextMenus, sendWebhook } = require('../background.js'));
+  });
+
+  afterEach(() => {
+    delete global.browser;
+    delete global.window;
+    delete global.fetch;
+    jest.resetModules();
+  });
+
+  test('creates context menu entries', async () => {
+    await createContextMenus();
+    expect(browser.contextMenus.create).toHaveBeenCalledWith(expect.objectContaining({ id: '1' }));
+  });
+
+  test('sendWebhook performs fetch', async () => {
+    const hook = { id: '1', label: 'Test', url: 'https://hook.test' };
+    await sendWebhook(hook, { title: 't', url: 'u', id: 1, windowId: 1, index:0, pinned:false, audible:false, mutedInfo:null, incognito:false, status:'complete' }, { selectionText: '' });
+    expect(fetchMock).toHaveBeenCalled();
+  });
+});

--- a/utils/sendWebhook.js
+++ b/utils/sendWebhook.js
@@ -1,0 +1,105 @@
+// Utility to send a webhook request
+if (typeof importScripts === 'function') {
+  importScripts('/utils/browser-polyfill.js');
+}
+
+let getBrowserAPI;
+try {
+  ({ getBrowserAPI } = require('./utils'));
+} catch (e) {
+  if (typeof window !== 'undefined' && window.getBrowserAPI) {
+    getBrowserAPI = window.getBrowserAPI;
+  }
+}
+
+const escapeRegExp = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+async function sendWebhook(hook, tab, info = {}) {
+  const browserAPI = getBrowserAPI ? getBrowserAPI() : (window.getBrowserAPI && window.getBrowserAPI());
+  const browserInfo = await (browserAPI.runtime.getBrowserInfo?.() || {});
+  const platformInfo = await (browserAPI.runtime.getPlatformInfo?.() || {});
+  const selectedText = info.selectionText || '';
+
+  let payload = {
+    tab: {
+      title: tab.title,
+      url: tab.url,
+      id: tab.id,
+      windowId: tab.windowId,
+      index: tab.index,
+      pinned: tab.pinned,
+      audible: tab.audible,
+      mutedInfo: tab.mutedInfo,
+      incognito: tab.incognito,
+      status: tab.status,
+    },
+    browser: browserInfo,
+    platform: platformInfo,
+    triggeredAt: new Date().toISOString(),
+  };
+
+  if (hook.sendSelectedText) {
+    payload.selectedText = selectedText;
+  }
+  if (hook.identifier) {
+    payload.identifier = hook.identifier;
+  }
+
+  if (hook.customPayload) {
+    try {
+      const replacements = {
+        '{{tab.title}}': tab.title,
+        '{{tab.url}}': tab.url,
+        '{{tab.id}}': tab.id,
+        '{{tab.windowId}}': tab.windowId,
+        '{{tab.index}}': tab.index,
+        '{{tab.pinned}}': tab.pinned,
+        '{{tab.audible}}': tab.audible,
+        '{{tab.incognito}}': tab.incognito,
+        '{{tab.status}}': tab.status,
+        '{{browser}}': JSON.stringify(browserInfo),
+        '{{platform.arch}}': platformInfo.arch || 'unknown',
+        '{{platform.os}}': platformInfo.os || 'unknown',
+        '{{platform.version}}': platformInfo.version,
+        '{{triggeredAt}}': new Date().toISOString(),
+        '{{identifier}}': hook.identifier || '',
+      };
+      if (hook.sendSelectedText) {
+        replacements['{{selectedText}}'] = selectedText;
+      }
+      let customPayloadStr = hook.customPayload;
+      Object.entries(replacements).forEach(([ph, val]) => {
+        const quoted = customPayloadStr.match(new RegExp(`"[^\"]*${escapeRegExp(ph)}[^\"]*"`, 'g'));
+        const replaceValue = typeof val === 'string'
+          ? (quoted ? val.replace(/"/g, '\\"') : `"${val.replace(/"/g, '\\"')}"`)
+          : (val === undefined ? 'null' : JSON.stringify(val));
+        customPayloadStr = customPayloadStr.replace(new RegExp(escapeRegExp(ph), 'g'), replaceValue);
+      });
+      payload = JSON.parse(customPayloadStr);
+    } catch (err) {
+      console.error('Failed to parse custom payload', err);
+    }
+  }
+
+  const headers = { 'Content-Type': 'application/json' };
+  if (Array.isArray(hook.headers)) {
+    hook.headers.forEach(h => { if (h.key && h.value) headers[h.key] = h.value; });
+  }
+  const method = hook.method || 'POST';
+  const fetchOpts = { method, headers };
+  let url = hook.url;
+  if (method === 'POST') {
+    fetchOpts.body = JSON.stringify(payload);
+  } else if (method === 'GET') {
+    const urlObj = new URL(url);
+    urlObj.searchParams.set('payload', encodeURIComponent(JSON.stringify(payload)));
+    url = urlObj.toString();
+  }
+  return fetch(url, fetchOpts);
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { sendWebhook };
+} else if (typeof window !== 'undefined') {
+  window.sendWebhook = sendWebhook;
+}


### PR DESCRIPTION
## Summary
- enable context menu access to trigger a webhook
- load context menu items from stored webhooks
- support new `contextMenuSend` i18n message
- document context menu usage in README
- test context menu logic
- centralize webhook sending logic for reuse in popup and background

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687934f0abc4832fbd3789f1d38a5c98