### PR TITLE
Refactor webhook loading

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -7,13 +7,19 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   const buttonsContainer = document.getElementById("buttons-container");
 
-  // Load webhooks from storage
-  const { webhooks = [] } = await browserAPI.storage.sync.get("webhooks");
+  let loadWebhooks;
+  let filterWebhooksByUrl;
+  try {
+    ({ loadWebhooks, filterWebhooksByUrl } = require("../utils/webhookUtils"));
+  } catch (e) {
+    loadWebhooks = window.loadWebhooks;
+    filterWebhooksByUrl = window.filterWebhooksByUrl;
+  }
+
   const tabs = await browserAPI.tabs.query({ active: true, currentWindow: true });
   const currentUrl = tabs[0]?.url || "";
-  const visibleWebhooks = webhooks.filter(
-    (wh) => !wh.urlFilter || currentUrl.includes(wh.urlFilter)
-  );
+  const webhooks = await loadWebhooks();
+  const visibleWebhooks = filterWebhooksByUrl(webhooks, currentUrl);
 
   if (visibleWebhooks.length === 0) {
     // Use textContent instead of innerHTML for security

--- a/tests/webhookUtils.test.js
+++ b/tests/webhookUtils.test.js
@@ -1,0 +1,36 @@
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+
+describe('webhook utils', () => {
+  afterEach(() => {
+    jest.resetModules();
+    delete global.browser;
+    delete global.window;
+  });
+
+  test('filterWebhooksByUrl filters correctly', () => {
+    const { filterWebhooksByUrl } = require('../utils/webhookUtils');
+    const hooks = [
+      { id: '1', urlFilter: 'example.com' },
+      { id: '2' }
+    ];
+    expect(filterWebhooksByUrl(hooks, 'https://example.com/page').length).toBe(2);
+    expect(filterWebhooksByUrl(hooks, 'https://other.com').length).toBe(1);
+  });
+
+  test('getVisibleWebhooks loads and filters', async () => {
+    const hooks = [
+      { id: '1', urlFilter: 'example.com' },
+      { id: '2' }
+    ];
+    const browser = { storage: { sync: { get: jest.fn().mockResolvedValue({ webhooks: hooks }) } } };
+    global.browser = browser;
+    global.window = { getBrowserAPI: () => browser };
+    const { getVisibleWebhooks } = require('../utils/webhookUtils');
+    const res = await getVisibleWebhooks('https://example.com');
+    expect(res.length).toBe(2);
+    const res2 = await getVisibleWebhooks('https://other.com');
+    expect(res2.length).toBe(1);
+  });
+});

--- a/utils/webhookUtils.js
+++ b/utils/webhookUtils.js
@@ -1,0 +1,31 @@
+let getBrowserAPI;
+try {
+  ({ getBrowserAPI } = require('./utils'));
+} catch (e) {
+  if (typeof window !== 'undefined' && window.getBrowserAPI) {
+    getBrowserAPI = window.getBrowserAPI;
+  }
+}
+
+async function loadWebhooks() {
+  const browserAPI = getBrowserAPI ? getBrowserAPI() : (typeof window !== 'undefined' && window.getBrowserAPI ? window.getBrowserAPI() : {});
+  const { webhooks = [] } = await browserAPI.storage.sync.get('webhooks');
+  return webhooks;
+}
+
+function filterWebhooksByUrl(webhooks = [], url = '') {
+  return webhooks.filter((wh) => !wh.urlFilter || url.includes(wh.urlFilter));
+}
+
+async function getVisibleWebhooks(url) {
+  const hooks = await loadWebhooks();
+  return filterWebhooksByUrl(hooks, url);
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { loadWebhooks, filterWebhooksByUrl, getVisibleWebhooks };
+} else if (typeof window !== 'undefined') {
+  window.loadWebhooks = loadWebhooks;
+  window.filterWebhooksByUrl = filterWebhooksByUrl;
+  window.getVisibleWebhooks = getVisibleWebhooks;
+}


### PR DESCRIPTION
## Summary
- centralize webhook load/filter logic into `utils/webhookUtils.js`
- reuse shared helpers in popup and background scripts
- hide context menu entries based on urlFilter
- test shared utilities

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68793d681444832fa5b35d080b4d4426